### PR TITLE
design: Login과 Main 각각 라우터에서 사용되는 레이아웃 분리해서 적용

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,31 @@
+import Navbar from "@/components/layout/Navbar/Navbar";
+import { css } from "@/styled-system/css";
+
+// main 전용 레이아웃
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        height: "100dvh",
+      })}
+    >
+      <Navbar
+        className={css({
+          position: "sticky",
+          top: "0",
+        })}
+      />
+      <main
+        className={css({
+          display: "flex",
+          flex: 1,
+          overflow: "auto",
+        })}
+      >
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,9 @@
-import Navbar from "@/components/layout/Navbar/Navbar";
 import "./globals.css";
-import { css } from "@/styled-system/css";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <body>
-        <Navbar
-          className={css({
-            position: "sticky",
-            top: "0",
-          })}
-        />
-        {children}
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,32 @@
+import Navbar from "@/components/layout/Navbar/Navbar";
+import { css } from "@/styled-system/css";
+
+// 로그인 전용 레이아웃
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        height: "100dvh",
+        overflow: "hidden",
+      })}
+    >
+      <Navbar
+        className={css({
+          position: "sticky",
+          top: "0",
+        })}
+      />
+      <main
+        className={css({
+          display: "flex",
+          flex: 1,
+          overflow: "hidden",
+        })}
+      >
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,35 @@
-import Navbar from "@/components/layout/Navbar/Navbar";
+import { css } from "@/styled-system/css";
 
+// 로그인
 export default function Page() {
-  return <div></div>;
+  return (
+    <div
+      className={css({
+        width: "100%",
+        height: "100%",
+        overflowY: "hidden",
+
+        background: "linear-gradient(to bottom right, #F0FAF4 0%, #FFFFFF 60%)",
+
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      })}
+    >
+      <div
+        className={css({
+          width: "420px",
+          height: "80vh",
+          overflowY: "hidden",
+
+          border: "1px solid",
+          borderColor: "green.100",
+          borderRadius: "16px",
+
+          bg: "white",
+          shadow: "0px 8px 32px 0px #00000010",
+        })}
+      ></div>
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 개요

- 로그인 페이지 레이아웃: Footer 미존재, 내부 콘텐츠 스크롤 불가능
- 나머지 페이지(회사소개 / 서비스소개 / 문의내역 / 견적문의) 레이아웃: Footer 존재, 내부 콘텐츠 스크롤 가능

---

## ✅ 작업 내용

- [x] LoginLayout
- [x] MainLayout

---

## 📷 작업 결과
### LoginLayout
<img width="1799" height="884" alt="image" src="https://github.com/user-attachments/assets/2724706d-f800-40df-871c-07d0925d0407" />

### MainLayout
<img width="1800" height="890" alt="image" src="https://github.com/user-attachments/assets/c12c2f01-84bc-4182-a412-54f8606c235d" />
---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

- Footer는 디자인 확정되고 추가 예정
