### PR TITLE
refactor: 로그인 에러 처리 로직 추가 및 버튼 비활성화 추가로 UX 개선

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,16 +3,26 @@
 import Button from "@/components/ui/Button/Button";
 import Input from "@/components/ui/Input/Input";
 import { css } from "@/styled-system/css";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 // 로그인
-export default function Page() {
+export default function LoginPage() {
+  const router = useRouter();
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
+  const [isError, setIsError] = useState<boolean>(false);
 
   // 로그인
-  function handleLogin() {
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
     // API 연동
+    if (id === "hskorea" && password === "hskorea123") {
+      router.push("/inquiry");
+    } else {
+      setIsError(true);
+    }
   }
 
   return (
@@ -75,6 +85,8 @@ export default function Page() {
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
+
+              marginBottom: "10px",
             })}
           >
             🔐
@@ -106,6 +118,7 @@ export default function Page() {
 
         {/* 아이디/비밀번호 입력 폼 */}
         <form
+          onSubmit={handleSubmit}
           className={css({
             width: "100%",
 
@@ -116,26 +129,36 @@ export default function Page() {
         >
           <Input
             value={id}
-            onChange={(e) => setId(e.target.value)}
+            onChange={(e) => {
+              setId(e.target.value);
+              setIsError(false);
+            }}
             type="text"
             label="아이디"
+            aria-label="아이디 입력"
             required
             placeholder="아이디를 입력하세요"
+            error={isError ? "존재하지 않는 아이디입니다" : undefined}
           />
           <Input
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            type="text"
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setIsError(false);
+            }}
+            type="password"
             label="비밀번호"
+            aria-label="비밀번호 입력"
             required
             placeholder="비밀번호를 입력하세요"
+            error={isError ? "비밀번호가 일치하지 않습니다" : undefined}
           />
           <Button
-            onClick={handleLogin}
             fullWidth
             className={css({
               py: "12px",
             })}
+            disabled={!id || !password}
           >
             로그인
           </Button>


### PR DESCRIPTION
## 📌 개요

- 로그인 페이지의 에러 처리 로직 추가
- 아이디와 비밀번호 모두 입력 시, 버튼 활성화되도록 수정하여 UX 개선

---

## ✅ 작업 내용

- [x] 로그인 에러 처리 로직
- [x] 로그인 버튼 활성화 상태 추가
- [x] ```aria-label``` 추가
- [x] 컴포넌트명 ```Page```에서 ```LoginPage```로 수정

---

## 📷 작업 결과

https://github.com/user-attachments/assets/8528b459-7f3b-4439-a0c5-81f9b876c4b9

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
