### PR TITLE
design: 서비스 소개 페이지 퍼블리싱

### DIFF
--- a/src/app/(main)/_components/ReasonSection.tsx
+++ b/src/app/(main)/_components/ReasonSection.tsx
@@ -1,6 +1,7 @@
 import { REASONS } from "@/constants/reason";
 import { css } from "@/styled-system/css";
 import SectionTitle from "@/components/ui/SectionTitle/SectionTitle";
+import { formatTwoDigit } from "@/utils/format";
 
 // 온보딩: 이유 섹션
 export default function ReasonSection() {
@@ -59,7 +60,7 @@ export default function ReasonSection() {
                 height: "fit",
               })}
             >
-              REASON {String(idx + 1).padStart(2, "0")}
+              REASON {formatTwoDigit(idx + 1)}
             </div>
             <h3
               className={css({

--- a/src/app/(main)/service/_components/ServiceIntroSection.tsx
+++ b/src/app/(main)/service/_components/ServiceIntroSection.tsx
@@ -45,9 +45,6 @@ export default function ServiceIntroSection() {
           {SERVICE_INTRODUCES.map((intro, idx) => (
             <ServiceCard
               className={css({
-                ...(idx === 4 && {
-                  gridColumn: { xl: "span 2" },
-                }),
                 alignItems: "flex-start",
               })}
               key={idx}

--- a/src/app/(main)/service/_components/ServiceIntroSection.tsx
+++ b/src/app/(main)/service/_components/ServiceIntroSection.tsx
@@ -1,0 +1,105 @@
+import SectionTitle from "@/components/ui/SectionTitle/SectionTitle";
+import ServiceCard from "@/components/ui/ServiceCard/ServiceCard";
+import { SERVICE_INTRODUCES } from "@/constants/serviceIntroduce";
+
+import { css } from "@/styled-system/css";
+import { formatTwoDigit } from "@/utils/format";
+
+// 서비스 소개 섹션
+export default function ServiceIntroSection() {
+  return (
+    <section
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        paddingX: { base: "20px", md: "150px" },
+        paddingY: "40px",
+        bg: "white",
+      })}
+    >
+      <article
+        className={css({
+          width: "100%",
+          maxWidth: "980px",
+          display: "flex",
+          flexDirection: "column",
+          rowGap: "24px",
+        })}
+      >
+        <SectionTitle
+          enTitle="SERVICE INTRODUCTION"
+          className={css({
+            width: "110px",
+          })}
+        >
+          서비스 소개
+        </SectionTitle>
+        <div
+          className={css({
+            display: "flex",
+            flexDirection: "column",
+            rowGap: { base: "10px", md: "20px" },
+          })}
+        >
+          {SERVICE_INTRODUCES.map((intro, idx) => (
+            <ServiceCard
+              className={css({
+                ...(idx === 4 && {
+                  gridColumn: { xl: "span 2" },
+                }),
+                alignItems: "flex-start",
+              })}
+              key={idx}
+              icon={intro.icon}
+              direction="column"
+            >
+              <div
+                className={css({
+                  display: "flex",
+                  flexDirection: "column",
+                  rowGap: "12px",
+                })}
+              >
+                <div
+                  className={css({
+                    display: "flex",
+                    columnGap: "8px",
+                    alignItems: "center",
+                  })}
+                >
+                  <p
+                    className={css({
+                      color: "orange.900",
+                      fontWeight: "bold",
+                      fontSize: "12px",
+                    })}
+                  >
+                    SERVICE {formatTwoDigit(idx + 1)}
+                  </p>
+                  <p
+                    className={css({
+                      color: "gray.900",
+                      fontWeight: "bold",
+                      fontSize: "16px",
+                    })}
+                  >
+                    {intro.title}
+                  </p>
+                </div>
+                <p
+                  className={css({
+                    color: "gray.700",
+                    fontSize: "16px",
+                  })}
+                >
+                  {intro.description}
+                </p>
+              </div>
+            </ServiceCard>
+          ))}
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/app/(main)/service/page.tsx
+++ b/src/app/(main)/service/page.tsx
@@ -1,4 +1,64 @@
-// 서비스소개
-export default function Page() {
-  return <div></div>;
+import HeroContainer from "@/components/layout/HeroContainer/HeroContainer";
+import ServiceIntroSection from "./_components/ServiceIntroSection";
+import Breadcrumb from "@/components/ui/Breadcrumb/Breadcrumb";
+import { css } from "@/styled-system/css";
+
+// 서비스 소개
+export default function ServicePage() {
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+      })}
+    >
+      <HeroContainer>
+        <div
+          className={css({
+            display: "flex",
+            flexDirection: "column",
+            rowGap: "16px",
+          })}
+        >
+          <Breadcrumb currentPageName="서비스 소개" />
+          {/* 제목 */}
+          <h1
+            className={css({
+              fontWeight: "bold",
+              fontSize: { base: "24px", md: "32px" },
+            })}
+          >
+            <span
+              className={css({
+                display: "block",
+                color: "white",
+              })}
+            >
+              믿을 수 있는 기업이전 파트너
+            </span>
+            <span
+              className={css({
+                display: "block",
+                color: "orange.400",
+              })}
+            >
+              에이치에스코리아
+            </span>
+          </h1>
+          <div
+            className={css({
+              width: "50px",
+              height: "3px",
+              bg: "orange.400",
+              borderRadius: "full",
+            })}
+          />
+        </div>
+      </HeroContainer>
+
+      {/* 서비스 소개 */}
+      <ServiceIntroSection />
+    </div>
+  );
 }

--- a/src/constants/serviceIntroduce.ts
+++ b/src/constants/serviceIntroduce.ts
@@ -1,0 +1,47 @@
+import OfficeIcon from "@/assets/svgs/building.svg";
+import ToolIcon from "@/assets/svgs/tool.svg";
+import SchoolIcon from "@/assets/svgs/school.svg";
+import BoxIcon from "@/assets/svgs/box.svg";
+import PaperIcon from "@/assets/svgs/paper.svg";
+
+interface ServiceIntroduceType {
+  title: string;
+  description: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+// 서비스 소개 페이지 아이템
+export const SERVICE_INTRODUCES: ServiceIntroduceType[] = [
+  {
+    title: "기업이사",
+    description:
+      "기업 환경에 맞춘 맞춤형 이전 서비스를 통해 업무 공백을 최소화하고 안정적인 이전을 제공합니다.",
+    icon: OfficeIcon,
+  },
+  {
+    title: "장비 / 중량물 이전",
+    description: "정밀 장비 및 중요 설비를 안전하게 포장·운송·설치하여 현장 리스크를 최소화합니다.",
+    icon: ToolIcon,
+  },
+  {
+    title: "관공서·교육기관 이전",
+    description:
+      "공공기관 및 교육시설의 특성을 고려한 체계적인 일정 관리와 안정적인 작업을 수행합니다.",
+    icon: SchoolIcon,
+  },
+  {
+    title: "도서관 이전",
+    description: "도서 분류 체계를 유지하며 이전하여 정확한 재배치와 효율적인 운영을 지원합니다.",
+    icon: SchoolIcon,
+  },
+  {
+    title: "문서보관",
+    description: "중요 문서를 안전하게 보관할 수 있는 체계적인 보관 시스템을 제공합니다.",
+    icon: BoxIcon,
+  },
+  {
+    title: "창고보관",
+    description: "기업 자산 및 물품을 안전하게 보관할 수 있는 효율적인 공간 운영을 제공합니다.",
+    icon: PaperIcon,
+  },
+];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -17,3 +17,8 @@ export const formatPhoneNumber = (value: string): string => {
 export const onlyNumber = (value: string): string => {
   return value.replace(/\D/g, "");
 };
+
+// 두자리 수로 변경
+export const formatTwoDigit = (idx: number): string => {
+  return String(idx).padStart(2, "0");
+};


### PR DESCRIPTION
## 📌 개요

- 서비스 소개 페이지 퍼블리싱 및 두자리 포맷 util 함수 생성
---

## ✅ 작업 내용

- [x] 두자리 포맷팅 util 함수 생성
- [x] 서비스 소개 페이지 퍼블리싱

---

## 📷 작업 결과
### 데스크탑
<img width="656" height="767" alt="image" src="https://github.com/user-attachments/assets/ee0a77ff-6efb-41f7-82b6-3ab95f155533" />

### 모바일
<img width="253" height="789" alt="image" src="https://github.com/user-attachments/assets/6cfcd699-247a-4dc0-b7ef-41269254f7db" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 서비스 소개 페이지 완성: 브레드크럼, 헤더(강조된 회사명), 장식 구분선 포함된 히어로 섹션 추가
  * 6개 서비스 카드 추가: 아이콘, 번호(두 자리 포맷), 제목, 설명으로 구성된 반응형 그리드
  * 번호를 2자리로 표시하는 형식 유틸 추가

* **Bug Fixes**
  * 리스트 항목의 번호 표기 로직 정리 및 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->