### PR TITLE
fix: 문의글 비밀번호 입력 페이지 레이아웃 UI 깨짐

### DIFF
--- a/src/app/(main)/inquiry/password/[id]/page.tsx
+++ b/src/app/(main)/inquiry/password/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function InquiryPasswordPage() {
     <div
       className={css({
         width: "100%",
-        height: "90dvh",
+        minHeight: "90dvh",
 
         paddingX: "30px",
 

--- a/src/app/(main)/inquiry/password/[id]/page.tsx
+++ b/src/app/(main)/inquiry/password/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function InquiryPasswordPage() {
     <div
       className={css({
         width: "100%",
-        height: "100%",
+        height: "90dvh",
 
         paddingX: "30px",
 

--- a/src/app/(main)/inquiry/password/[id]/page.tsx
+++ b/src/app/(main)/inquiry/password/[id]/page.tsx
@@ -47,6 +47,7 @@ export default function InquiryPasswordPage() {
       <div
         className={css({
           width: "560px",
+          maxHeight: "430px",
           height: { base: "75vh", md: "50vh" },
           overflowY: "hidden",
 


### PR DESCRIPTION
## 📌 개요

- 문의글 비밀번호 입력 페이지 레이아웃 UI 깨짐

---

## ✅ 작업 내용

- [x] height 수정

---

## 📷 작업 결과
### 데스크탑
<img width="1800" height="933" alt="image" src="https://github.com/user-attachments/assets/0c802cab-0f33-44ac-9a1a-53bc99190fce" />

### 모바일
<img width="389" height="844" alt="image" src="https://github.com/user-attachments/assets/ff33a055-12cb-4067-b786-2073e6d88658" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [x] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 페이지 컨테이너의 수직 레이아웃 높이를 뷰포트 기반 단위로 조정하여 브라우저에서의 페이지 크기 계산을 개선했습니다. 이로 인해 모든 화면 크기에서 페이지가 더욱 일관되게 표시됩니다.
  * 내부 카드의 최대 높이를 제한해 과도한 세로 확장을 방지하고, 기존의 반응형 높이 및 스크롤 동작은 유지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->